### PR TITLE
Fix typo in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Convert AMD files to ES2016 modules, so they can be included in a Rollup bundle.
 
 ```js
 import { rollup } from 'rollup';
-import amd from 'rollup-pluign-amd';
+import amd from 'rollup-plugin-amd';
 
 rollup({
     entry: 'main.js',
@@ -41,7 +41,7 @@ React.render();
 
 ```js
 import { rollup } from 'rollup';
-import amd form 'rollup-pluign-amd';
+import amd form 'rollup-plugin-amd';
 
 rollup({
     entry: 'main.js',
@@ -75,7 +75,7 @@ If you're converting AMD modules from requirejs, you can use [node-module-lookup
 
 ```js
 import { rollup } from 'rollup';
-import amd form 'rollup-pluign-amd';
+import amd form 'rollup-plugin-amd';
 import lookup from 'module-lookup-amd';
 
 rollup({


### PR DESCRIPTION
Copy paste of examples does not work due to typo `plugin` not `pluign`