### PR TITLE
Add Sourcemap Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ rollup({
         amd({
             include: 'src/**', // Optional, Default: undefined (everything)
             exclude: [ 'node_modules/**' ], // Optional, Default: undefined (nothing)
-            converter: {}, // Optional, Default: undefined
+            converter: {}, // Optional, Default: { sourceMap: true }
             rewire: function (moduleId, parentPath) { // Optional, Default: false
                 return './basePath/' + moduleId;
             }
@@ -58,7 +58,16 @@ rollup({
 });
 ```
 
-* __converter__ options to pass down to the AMD to ES6 [converter](https://github.com/buxlabs/amd-to-es6).
+* __converter__ options to pass down to the AMD to ES6 [converter](https://github.com/buxlabs/amd-to-es6#options).
+  - Please note that `converter` option is set to `{ sourceMap: true }` by default. If you want to disable sourcemap, you can set it as `{ sourceMap: false }`. However, this may bring some [sourcemap related issues](https://rollupjs.org/guide/en/#warning-sourcemap-is-likely-to-be-incorrect)
+  - Other options for converter can be passed down in the same way as we set the sourcemap
+    ```js
+    converter: {
+        sourceMap: true, // Default
+        someOtherOption: someOtherOptionValue
+        ...
+    }
+    ```
 
 * __rewire__ allows to modify the imported path of `define` dependencies.
   - `moduleId` is the dependency ID


### PR DESCRIPTION
## Add sourcemap support
This pull request focuses on solving the sourcemap issue pointed out at https://github.com/piuccio/rollup-plugin-amd/issues/10

## Why the sourcemap issue occured
This happened because Rollup assumes every plugin that is transforming code is likely to be generating sourcemap for it (https://rollupjs.org/guide/en/#warning-sourcemap-is-likely-to-be-incorrect). If the sourcemap is not generated, Rollup logs an error `"Sourcemap is likely to be incorrect"`

## How is this achieved
The new version for [amd-to-es6](https://github.com/buxlabs/amd-to-es6) added support for sourcemap, so the `sourceMap: true` option is passed down as `default` to the amd-to-es6 converter. It generates the sourcemap and returns the code and the sourcemap in the form of an object, which is passed down to rollup for futher process.